### PR TITLE
Exercise 1.1.1 complete!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/*
+*.class
+testfiles/*

--- a/chapter1/Ex_1_1_1.java
+++ b/chapter1/Ex_1_1_1.java
@@ -1,0 +1,42 @@
+package chapter1;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import util.CalcTime;
+
+public class Ex_1_1_1 {
+    private static final String PROJECT_DIR = System.getProperty("user.dir");
+    private static final String READ_PATH = PROJECT_DIR + "/testfiles/ex_1_1_1_read.txt";
+    private static final String WRITE_PATH = PROJECT_DIR + "/testfiles/ex_1_1_1_write.txt";
+
+    public static void main(final String[] args) {
+
+        Runnable runnable = () -> {
+            Path read_path = Paths.get(READ_PATH);
+            Path write_path = Paths.get(WRITE_PATH);
+            try {
+                List<String> lines = Files.readAllLines(read_path, StandardCharsets.UTF_8);
+                Collections.reverse(lines);
+                try (BufferedWriter writer = Files.newBufferedWriter(write_path)) {
+                    for (String str : lines) {
+                        writer.append(str);
+                        writer.newLine();
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } catch (final IOException e) {
+                e.printStackTrace();
+            }
+        };
+
+        CalcTime.calcTime(runnable);
+    }
+}

--- a/util/CalcTime.java
+++ b/util/CalcTime.java
@@ -1,0 +1,11 @@
+package util;
+
+public class CalcTime {
+    public static void calcTime(Runnable runnable) {
+        long start = System.nanoTime();
+        runnable.run();
+        long end = System.nanoTime();
+        double elapsedTimeInSecond = (double) (end - start) / 1000000000;
+        System.out.println(elapsedTimeInSecond + " seconds");
+    }
+}


### PR DESCRIPTION
# Exercise 1.1.1
## 概要
入力を一行ずつ読んで逆順で返す

## 実装方法
`Runnable`インターフェースでやりたいことを実装して、`CalcTime.calcTime(Runnable runnable)`で実行させることで今後も実行時間を図っていく方針にしている。

相対パスの解決法がよくわからなかったので、プロジェクトのパスを`System.getProperty("user.dir")`で取ってきてそこに文字列を結合して入力と出力のファイルのパスを指定している。

ファイルの読み込みでreadAllLinesを使ったのはここを参考にした
https://qiita.com/motoki1990/items/755c1b0c8d12b49b0c77

書き込みはBufferWriterだなと思いつつここを参考にした
https://qiita.com/riekure/items/31c1a9e371c9020a4973

## 検証
testfilesというディレクトリを作って、ex_1_1_1_read.txtを用意する。
これを逆順にしてex_1_1_1_write.txtに出力する。

calcTimeで実行時間を計測している。
100万行でどのくらい時間がかかるのかを試す。

```
$ cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1000000 > testfiles/ex_1_1_1_read.txt

$ javac chapter1/Ex_1_1_1.java

$ java chapter1.Ex_1_1_1
0.2364477 seconds
```

ひとまず十分な速さは出てるかな

## よくわかってないこと
`try`をネストしているのが気持ちわるいんだけど、こういう場合ってどういう書き方がきれい？？
一番近い`catch`を参考にすると思うので、ネストしている`catch`って不要？？